### PR TITLE
Bump Packer to 1.4.0

### DIFF
--- a/packer.io/packer.io.spec
+++ b/packer.io/packer.io.spec
@@ -1,5 +1,5 @@
 Name: packer.io
-Version: 1.3.5
+Version: 1.4.0
 Release: 1%{?dist}
 Summary: Create machine and container images for multiple platforms
 Group: Development/Tools
@@ -29,6 +29,9 @@ popd
 %{_bindir}/*
 
 %changelog
+* Mon May 13 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.0-1
+- Update to 1.4.0
+
 * Wed Mar 27 2019 David Sastre <d.sastre.medina@gmail.com> - 1.3.5-1
 - Update to 1.3.5
 


### PR DESCRIPTION
Packer 1.4.0 has been released upstream, bump version in spec file.