### PR TITLE
Bump packer to v1.4.2

### DIFF
--- a/packer.io/packer.io.spec
+++ b/packer.io/packer.io.spec
@@ -1,5 +1,5 @@
 Name: packer.io
-Version: 1.4.1
+Version: 1.4.2
 Release: 1%{?dist}
 Summary: Create machine and container images for multiple platforms
 Group: Development/Tools
@@ -29,6 +29,9 @@ popd
 %{_bindir}/*
 
 %changelog
+* Wed Jul 10 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.2-1
+- Update to 1.4.2
+
 * Mon May 27 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.1-1
 - Update to 1.4.1
 


### PR DESCRIPTION
Hashicorp has released 1.4.2, bump the spec.