### PR TITLE
Update packer to v1.4.5

### DIFF
--- a/packer.io/packer.io.spec
+++ b/packer.io/packer.io.spec
@@ -29,7 +29,7 @@ popd
 %{_bindir}/*
 
 %changelog
-* Thu Nov 26 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.5-1
+* Tue Nov 26 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.5-1
 - Update to 1.4.5
 
 * Thu Oct 10 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.4-1

--- a/packer.io/packer.io.spec
+++ b/packer.io/packer.io.spec
@@ -1,5 +1,5 @@
 Name: packer.io
-Version: 1.4.4
+Version: 1.4.5
 Release: 1%{?dist}
 Summary: Create machine and container images for multiple platforms
 Group: Development/Tools
@@ -29,6 +29,9 @@ popd
 %{_bindir}/*
 
 %changelog
+* Thu Nov 26 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.5-1
+- Update to 1.4.5
+
 * Thu Oct 10 2019 David Sastre <d.sastre.medina@gmail.com> - 1.4.4-1
 - Update to 1.4.4
 


### PR DESCRIPTION
Hashicorp has released packer 1.4.5, bump the spec to trigger a build.